### PR TITLE
Stop the full screen loader if the validators fail

### DIFF
--- a/PayFabric/Payment/view/frontend/web/js/view/payment/method-renderer/payment-method.js
+++ b/PayFabric/Payment/view/frontend/web/js/view/payment/method-renderer/payment-method.js
@@ -145,6 +145,8 @@ define(
                         });
 
                     return false;
+                } else {
+                    fullScreenLoader.stopLoader();
                 }
             },
             validate: function() {


### PR DESCRIPTION
Other modules that perform additional validation checks can cause validation to fail, in which case the triggered full-screen loader remains on screen and the customer cannot proceed.

Notably, Avalara's Address Validation can cause validation failure, and will pop-up a dialog asking the customer to confirm the billing address.  Before this fix, such a dialog would pop-up underneath the full-screen loader and block the customer from continuing their checkout experience.